### PR TITLE
Fix support for RTL

### DIFF
--- a/plugin.video.united.search/resources/lib/unitedsearch.py
+++ b/plugin.video.united.search/resources/lib/unitedsearch.py
@@ -21,7 +21,15 @@ def _get_directory_threaded( us, directory ):
     us.result = []
     for item in us.get_directory(directory):
         us.result.append(item)
-
+        
+def is_rtl(string):
+    if any([(ord(char) >= 1424 and ord(char) <= 1514) for char in string]) or \
+       any([(ord(char) >= 64285 and ord(char) <= 64335) for char in string]) or \
+       any([(ord(char) >= 64336 and ord(char) <= 65023) for char in string]) or \
+       any([(ord(char) >= 1536 and ord(char) <= 1791) for char in string]) or \
+       any([(ord(char) >= 65136 and ord(char) <= 65279) for char in string]):
+           return True
+ 
 class UnitedSearch(object):
     def __init__( self ):
         self.__load_supported_addons()
@@ -37,7 +45,11 @@ class UnitedSearch(object):
             kbd.setHeading(_('Search'))
             kbd.doModal()
             if kbd.isConfirmed():
-                keyword = kbd.getText()
+                text = kbd.getText()
+                if is_rtl(text.decode('utf-8')):
+                    keyword = text.decode('utf-8')[::-1]
+                else:
+                    keyword = text
 
         if keyword:
             succeeded = True

--- a/plugin.video.united.search/resources/lib/unitedsearch.py
+++ b/plugin.video.united.search/resources/lib/unitedsearch.py
@@ -45,11 +45,7 @@ class UnitedSearch(object):
             kbd.setHeading(_('Search'))
             kbd.doModal()
             if kbd.isConfirmed():
-                text = kbd.getText()
-                if is_rtl(text.decode('utf-8')):
-                    keyword = text.decode('utf-8')[::-1]
-                else:
-                    keyword = text
+                keyword = kbd.getText()
 
         if keyword:
             succeeded = True
@@ -125,6 +121,8 @@ class UnitedSearch(object):
                 yield file
 
     def __get_learned_directory( self, directory, keyword ):
+        if is_rtl(keyword.decode('utf-8')):
+            keyword = keyword.decode('utf-8')[::-1]
         t = threading.Thread(target=_get_directory_threaded, args = (self, directory))
         t.start()
 


### PR DESCRIPTION
This is a workaround,
looks lie RTL is passed mirrored in this code:
https://github.com/vlmaksime/plugin.video.united.search/blob/master/plugin.video.united.search/resources/lib/unitedsearch.py#L327-L331

clouldnt find a way to fix it so I created a function to reverse RTL input (hebrew, arabic etc) in advance